### PR TITLE
プロジェクト関連のステート管理のため、コンテキストを別ファイルに移動

### DIFF
--- a/src/components/Project/CreateProject.jsx
+++ b/src/components/Project/CreateProject.jsx
@@ -1,40 +1,12 @@
-import React, { createContext, useState, useEffect } from 'react'
+import React, { createContext, useState } from 'react'
 import { Stepper, Step, StepLabel } from '@material-ui/core'
 import ProjectForm from './ProjectForm'
 import ReturnForm from './ReturnForm'
 import ProjectConfirm from './ProjectConfirm'
-import { EditorState } from 'draft-js';
-
-export const ProjectDataContext = createContext();
-export const ReturnDataContext = createContext();
+import { ProjectDataProvider, ReturnDataProvider } from '../../contexts/ProjectContext';
 
 const CreateProject = () => {
   const [activeStep, setActiveStep] = useState(0);
-  const [projectFormData, setProjectFormData] = useState({
-    title: '',
-    catch_copies: [''],
-    goal_amount: '',
-    start_date: '',
-    end_date: '',
-    project_images: [''],
-    description: '',
-  });
-  const [returnFormData, setReturnFormData] = useState({
-    returns: [
-      {
-        name: '',
-        description: '',
-        price: '',
-        stock_count: ''
-      }
-    ]
-  });
-  const [imagePreviews, setImagePreviews] = useState([]);
-  const [apiImageFiles, setApiImageFiles] = useState([]);
-  const [returnImagePreviews, setReturnImagePreviews] = useState([]);
-  const [apiReturnImageFiles, setAipReturnImageFiles] = useState([]);
-  const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
-  const [published, setPublished] = useState(false);
 
   const getSteps = () => {
     return ['プロジェクト情報の入力', 'リターンの追加', '確認'];
@@ -72,29 +44,11 @@ const CreateProject = () => {
           </Step>
         ))}
       </Stepper>
-      <ProjectDataContext.Provider value={{
-        projectFormData,
-        setProjectFormData,
-        imagePreviews,
-        setImagePreviews,
-        apiImageFiles,
-        setApiImageFiles,
-        published,
-        setPublished,
-        editorState,
-        setEditorState,
-      }}>
-        <ReturnDataContext.Provider value={{
-        returnFormData,
-        setReturnFormData,
-        apiReturnImageFiles,
-        setAipReturnImageFiles,
-        returnImagePreviews,
-        setReturnImagePreviews
-        }}>
+      <ProjectDataProvider>
+        <ReturnDataProvider>
           {renderStepContent(activeStep)}
-        </ReturnDataContext.Provider>
-      </ProjectDataContext.Provider>
+        </ReturnDataProvider>
+      </ProjectDataProvider>
     </>
   )
 }

--- a/src/components/Project/ProjectConfirm.jsx
+++ b/src/components/Project/ProjectConfirm.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { Grid, Button, Typography, FormControlLabel, Checkbox } from '@material-ui/core';
-import { ProjectDataContext } from './CreateProject';
-import { ReturnDataContext } from './CreateProject';
+import { ProjectDataContext } from '../../contexts/ProjectContext';
+import { ReturnDataContext } from '../../contexts/ProjectContext';
 import clientApi from '../../api/client';
 import Cookies from 'js-cookie';
 import { convertFromRaw } from 'draft-js';

--- a/src/components/Project/ProjectForm.jsx
+++ b/src/components/Project/ProjectForm.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { Grid, Button, TextField } from '@material-ui/core';
-import { ProjectDataContext } from './CreateProject';
+import { ProjectDataContext } from '../../contexts/ProjectContext';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { ja } from 'date-fns/locale';
@@ -27,7 +27,6 @@ const ProjectForm = ({ handleNext }) => {
     formState: { errors },
     setValue,
     watch,
-    register,
   } = useForm({
     defaultValues: projectFormData,
   });
@@ -117,7 +116,6 @@ const ProjectForm = ({ handleNext }) => {
       });
 
       if (response.status === 200) {
-        console.log('urlが返ってきました：', response.data)
         const imageUrl = response.data;
         return { data: { link: imageUrl } };
       } else {

--- a/src/components/Project/ProjectForm.jsx
+++ b/src/components/Project/ProjectForm.jsx
@@ -251,7 +251,6 @@ const ProjectForm = ({ handleNext }) => {
             <input
               type='file'
               multiple
-              // {...register('project_images', { required: '少なくとも1つのプロジェクト画像が必要です' })}
               onChange={addProjectImage}
             />
             {errors.project_images && <p style={{ color: 'red' }}>{errors.project_images.message}</p>}

--- a/src/components/Project/ReturnForm.jsx
+++ b/src/components/Project/ReturnForm.jsx
@@ -22,6 +22,8 @@ const ReturnForm = ({ handleNext, handleBack }) => {
     defaultValues: returnFormData,
   });
   const watchedFields = watch();
+  const [returnImageErrors, setReturnImageErrors] = useState([]);
+
 
   useEffect(() => {
     setReturnFormData((prevReturnFormData) => ({
@@ -43,6 +45,18 @@ const ReturnForm = ({ handleNext, handleBack }) => {
   }, [fields, setReturnFormData]);
 
   const onSubmit = (data) => {
+    const newErrors = Array(fields.length).fill('');
+    fields.forEach((_, index) => {
+      if (!returnImagePreviews[index]) {
+        newErrors[index] = 'リターン画像を選択してください';
+      }
+    });
+    setReturnImageErrors(newErrors);
+
+    if (newErrors.some((error) => error !== '')) {
+      return;
+    }
+
     handleNext()
     console.log('リターンフォーム「次へ」押下時）：', returnFormData, apiReturnImageFiles);
   }
@@ -68,6 +82,12 @@ const ReturnForm = ({ handleNext, handleBack }) => {
       newReturnImagePreviews[index] = imageUrl;
       return newReturnImagePreviews;
     });
+
+    setReturnImageErrors((prevErrors) => {
+      const newErrors = [...prevErrors];
+      newErrors[index] = '';
+      return newErrors;
+    })
   };
 
   const removeReturnImage = (index) => {
@@ -111,13 +131,11 @@ const ReturnForm = ({ handleNext, handleBack }) => {
             {/* リターン画像 */}
             <div>
               <h3>リターンの画像</h3>
-              <input
-                type='file'
-                onChange={(e) => addReturnImage(e, index)}
-                {...register(`returns.${index}.return_image`, { required: 'リターン画像を選択してください' })}
-              />
-              {errors?.returns?.[index]?.return_image && <p style={{ color: 'red' }}>{errors?.returns?.[index]?.return_image.message}</p>}
+              <input type='file' onChange={(e) => addReturnImage(e, index)} />
             </div>
+            {returnImageErrors[index] && (
+              <p style={{ color: 'red' }}>{returnImageErrors[index]}</p>
+            )}
             {returnImagePreviews[index] && (
               <div>
                 <img src={returnImagePreviews[index]} alt={`プレビュー${index + 1}`} style={{ width: '200px', height: '200px' }} />

--- a/src/components/Project/ReturnForm.jsx
+++ b/src/components/Project/ReturnForm.jsx
@@ -1,8 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { Grid, Button, TextField, Tooltip } from '@material-ui/core';
-import { ReturnDataContext } from './CreateProject';
-
+import { ReturnDataContext } from '../../contexts/ProjectContext';
 
 const ReturnForm = ({ handleNext, handleBack }) => {
   const {

--- a/src/contexts/ProjectContext.jsx
+++ b/src/contexts/ProjectContext.jsx
@@ -1,0 +1,70 @@
+import React, { createContext, useState } from 'react'
+import { EditorState } from 'draft-js';
+
+export const ProjectDataContext = createContext();
+export const ReturnDataContext = createContext();
+
+export const ProjectDataProvider = ({ children }) => {
+  const [projectFormData, setProjectFormData] = useState({
+    title: '',
+    catch_copies: [''],
+    goal_amount: '',
+    start_date: '',
+    end_date: '',
+    project_images: [''],
+    description: '',
+  });
+  const [imagePreviews, setImagePreviews] = useState([]);
+  const [apiImageFiles, setApiImageFiles] = useState([]);
+  const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
+  const [published, setPublished] = useState(false);
+
+  return (
+    <ProjectDataContext.Provider
+      value={{
+        projectFormData,
+        setProjectFormData,
+        imagePreviews,
+        setImagePreviews,
+        apiImageFiles,
+        setApiImageFiles,
+        published,
+        setPublished,
+        editorState,
+        setEditorState,
+      }}
+    >
+      {children}
+    </ProjectDataContext.Provider>
+  );
+};
+
+export const ReturnDataProvider = ({ children }) => {
+  const [returnFormData, setReturnFormData] = useState({
+    returns: [
+      {
+        name: '',
+        description: '',
+        price: '',
+        stock_count: ''
+      }
+    ]
+  });
+  const [returnImagePreviews, setReturnImagePreviews] = useState([]);
+  const [apiReturnImageFiles, setAipReturnImageFiles] = useState([]);
+
+  return (
+    <ReturnDataContext.Provider
+      value={{
+        returnFormData,
+        setReturnFormData,
+        apiReturnImageFiles,
+        setAipReturnImageFiles,
+        returnImagePreviews,
+        setReturnImagePreviews
+      }}
+    >
+      {children}
+    </ReturnDataContext.Provider>
+  );
+}


### PR DESCRIPTION
【実装内容】

- 今後プロジェクト編集機能においてもプロジェクト作成機能で使っていたステート管理を使用するため、CreateProjectコンポーネント内で定義していたコンテキストを、新たに作成したsrc/contexts/ProjectContext.jsxにて改めて定義しなおしました。

- また、以前実装していたリターン画像のバリデーションにregisterを使用していましたが、それが影響してリターン画像のステート管理に問題があったので、バリデーションを別の方法で対応しました。