### PR TITLE
add プロジェクト編集機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.4.0",
         "axios-case-converter": "^1.1.0",
         "draft-js": "^0.10.5",
+        "draft-js-image-plugin": "^2.0.7",
         "draftjs-to-html": "^0.9.1",
         "js-cookie": "^3.0.5",
         "quill": "^1.3.7",
@@ -8478,6 +8479,28 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0",
         "react-dom": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0"
+      }
+    },
+    "node_modules/draft-js-image-plugin": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/draft-js-image-plugin/-/draft-js-image-plugin-2.0.7.tgz",
+      "integrity": "sha512-yy3GXquNWZ7u5WpIvEf6J3QNArFYLOqpVfRoKopcRSze9CFHDO+VfeQlK95GfpTq7GykRy7tBD5qqq4tQcQ3bQ==",
+      "deprecated": "use @draft-js-plugins/image >=v4 instead",
+      "dependencies": {
+        "clsx": "^1.0.4"
+      },
+      "peerDependencies": {
+        "draft-js": "^0.10.1 || ^0.11.0",
+        "react": "^15.5.0 || ^16.0.0-rc",
+        "react-dom": "^15.5.0 || ^16.0.0-rc"
+      }
+    },
+    "node_modules/draft-js-image-plugin/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/draftjs-to-html": {
@@ -26385,6 +26408,21 @@
         "fbjs": "^0.8.15",
         "immutable": "~3.7.4",
         "object-assign": "^4.1.0"
+      }
+    },
+    "draft-js-image-plugin": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/draft-js-image-plugin/-/draft-js-image-plugin-2.0.7.tgz",
+      "integrity": "sha512-yy3GXquNWZ7u5WpIvEf6J3QNArFYLOqpVfRoKopcRSze9CFHDO+VfeQlK95GfpTq7GykRy7tBD5qqq4tQcQ3bQ==",
+      "requires": {
+        "clsx": "^1.0.4"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
       }
     },
     "draftjs-to-html": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.4.0",
     "axios-case-converter": "^1.1.0",
     "draft-js": "^0.10.5",
+    "draft-js-image-plugin": "^2.0.7",
     "draftjs-to-html": "^0.9.1",
     "js-cookie": "^3.0.5",
     "quill": "^1.3.7",

--- a/src/components/Project/CreateProject.jsx
+++ b/src/components/Project/CreateProject.jsx
@@ -1,9 +1,8 @@
-import React, { createContext, useState } from 'react'
+import React, { useState } from 'react'
 import { Stepper, Step, StepLabel } from '@material-ui/core'
 import ProjectForm from './ProjectForm'
 import ReturnForm from './ReturnForm'
 import ProjectConfirm from './ProjectConfirm'
-import { ProjectDataProvider, ReturnDataProvider } from '../../contexts/ProjectContext';
 
 const CreateProject = () => {
   const [activeStep, setActiveStep] = useState(0);
@@ -44,11 +43,7 @@ const CreateProject = () => {
           </Step>
         ))}
       </Stepper>
-      <ProjectDataProvider>
-        <ReturnDataProvider>
-          {renderStepContent(activeStep)}
-        </ReturnDataProvider>
-      </ProjectDataProvider>
+      {renderStepContent(activeStep)}
     </>
   )
 }

--- a/src/components/Project/CreatedProjectList.jsx
+++ b/src/components/Project/CreatedProjectList.jsx
@@ -36,9 +36,8 @@ const CreatedProjectList = () => {
       <div key={project.id}>
         <h2>{project.title}</h2>
         <h2>プロジェクトID:{project.id}</h2>
-        {console.log('Project images:', project.projectImages)}
         {project.projectImages && project.projectImages[0] ? (
-          <img src={project.projectImages[0].url} alt={project.title} />
+          <img src={project.projectImages[0].url} alt={project.title} style={{width: '300px'}} />
         ) : (
           <p>プロジェクト画像がありません</p>
         )}
@@ -46,7 +45,6 @@ const CreatedProjectList = () => {
       </div>
     ))}
   </div>
-
   )
 }
 

--- a/src/components/Project/EditProject.jsx
+++ b/src/components/Project/EditProject.jsx
@@ -1,0 +1,152 @@
+import React, { useState, useContext, useEffect } from 'react'
+import { Stepper, Step, StepLabel } from '@material-ui/core'
+import ProjectForm from './ProjectForm'
+import ReturnForm from './ReturnForm'
+import ProjectConfirm from './ProjectConfirm'
+import { ProjectDataContext, ReturnDataContext } from '../../contexts/ProjectContext';
+import { useParams } from 'react-router-dom'
+import clientApi from '../../api/client'
+import Cookies from 'js-cookie'
+import { parseISO } from 'date-fns'
+import { convertFromRaw, EditorState } from 'draft-js';
+
+const createEditorStateFormDescription = (descriptionData) => {
+  const contentState = convertFromRaw({
+    blocks: descriptionData.blocks,
+    entityMap: descriptionData.entityMap,
+  });
+
+  return EditorState.createWithContent(contentState);
+}
+
+const EditProject = () => {
+  const { project_id } = useParams();
+  const { setProjectFormData, setImagePreviews, setApiImageFiles, setEditorState, setPublished, setIsEdit } = useContext(ProjectDataContext);
+  const { setReturnFormData, setReturnImagePreviews, setApiReturnImageFiles, returnFormData } = useContext(ReturnDataContext);
+  const [activeStep, setActiveStep] = useState(0);
+  setIsEdit(true);
+
+  // 登録済のプロジェクト情報を取得しステートにセットする。
+  useEffect(() => {
+    const fetchProjectData = async () => {
+      try {
+        const headers = {
+          'access-token': Cookies.get('_access_token'),
+          'client': Cookies.get('_client'),
+          'uid': Cookies.get('_uid'),
+        };
+
+        const response = await clientApi.get(`/projects/${project_id}`, {
+          headers: headers,
+        });
+
+        const projectData = response.data;
+
+        let catchCopiesArray = [];
+        catchCopiesArray = JSON.parse(projectData.catchCopies);
+
+        const start_date = parseISO(projectData.startDate);
+        const end_date = parseISO(projectData.endDate);
+
+        const projectImagesArray = projectData.projectImages.map(image => image.url);
+
+        const projectImagesBlobs = await Promise.all(
+          projectImagesArray.map(async (imageUrl) => {
+            const imageResponse = await fetch(imageUrl);
+            const blob = await imageResponse.blob();
+            return blob;
+          })
+        )
+
+        console.log('projectImagesBlobs', projectImagesBlobs)
+
+        const descriptionData = JSON.parse(projectData.description);
+        const descriptionEditorState = createEditorStateFormDescription(descriptionData);
+
+        setProjectFormData({
+          title: projectData.title,
+          catch_copies: catchCopiesArray,
+          goal_amount: projectData.goalAmount,
+          start_date: start_date,
+          end_date: end_date,
+        })
+
+        console.log('projectImagesArray', projectImagesArray)
+
+        setImagePreviews(projectImagesArray);
+        setApiImageFiles(projectImagesBlobs);
+
+        setEditorState(descriptionEditorState);
+
+        console.log('descriptionData', descriptionData)
+
+        const initialReturns = projectData.returns.map(returnData => ({
+          name: returnData.name,
+          description: returnData.description,
+          price: returnData.price,
+          stock_count: returnData.stockCount,
+          id: returnData.id,
+        }));
+
+        setReturnFormData({
+          returns: initialReturns
+        });
+
+        const initialReturnImagePreviews = projectData.returns.map(returnData =>
+          returnData.returnImage.url
+        );
+        setReturnImagePreviews(initialReturnImagePreviews);
+
+        setPublished(projectData.isPublished)
+
+        console.log('API レスポンス', projectData)
+      } catch (error) {
+        console.error('API レスポンスの取得に失敗しました', error);
+      }
+    };
+
+    fetchProjectData();
+  }, [])
+
+  const getSteps = () => {
+    return ['プロジェクト情報の編集', 'リターンの編集', '確認'];
+  }
+  const steps = getSteps();
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  }
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  }
+
+  const renderStepContent = (stepIndex) => {
+    switch (stepIndex) {
+      case 0:
+        return <ProjectForm  handleNext={handleNext}/>;
+      case 1:
+        return <ReturnForm handleNext={handleNext} handleBack={handleBack} />;
+      case 2:
+        return <ProjectConfirm handleBack={handleBack} />;
+      default:
+        return 'ステップが見つかりません。';
+    }
+  };
+
+  return (
+    <>
+      <h1>プロジェクト編集</h1>
+      <Stepper activeStep={activeStep} alternativeLabel>
+        {steps.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      {renderStepContent(activeStep)}
+    </>
+  )
+}
+
+export default EditProject

--- a/src/components/Project/ResizeProjectImages.jsx
+++ b/src/components/Project/ResizeProjectImages.jsx
@@ -1,0 +1,48 @@
+
+export const resizeProjectImages = async (file, targetWidth, targetHeight) => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const reader = new FileReader();
+
+    reader.onload = function (e) {
+      img.src = e.target.result;
+
+      img.onload = async function () {
+        const originalWidth = img.width;
+        const originalHeight = img.height;
+
+        const scaleFactorWidth = targetWidth / originalWidth;
+        const scaleFactorHeight = targetHeight / originalHeight;
+        const scaleFactor = Math.max(scaleFactorWidth, scaleFactorHeight);
+
+        const newWidth = originalWidth * scaleFactor;
+        const newHeight = originalHeight * scaleFactor;
+
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+
+        const offsetX = (targetWidth - newWidth) / 2;
+        const offsetY = (targetHeight - newHeight) / 2;
+
+        ctx.drawImage(img, offsetX, offsetY, newWidth, newHeight);
+
+        canvas.toBlob((blob) => {
+          resolve(blob);
+        }, "image/jpeg", 1.0);
+      };
+
+      img.onerror = function (error) {
+        reject(error);
+      };
+    };
+
+    reader.onerror = function (error) {
+      reject(error);
+    };
+
+    reader.readAsDataURL(file);
+  });
+};

--- a/src/components/Project/ReturnForm.jsx
+++ b/src/components/Project/ReturnForm.jsx
@@ -2,13 +2,14 @@ import React, { useContext, useEffect, useState } from 'react'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { Grid, Button, TextField, Tooltip } from '@material-ui/core';
 import { ReturnDataContext } from '../../contexts/ProjectContext';
+import { resizeProjectImages } from './ResizeProjectImages';
 
 const ReturnForm = ({ handleNext, handleBack }) => {
   const {
     returnFormData,
     setReturnFormData,
     apiReturnImageFiles,
-    setAipReturnImageFiles,
+    setApiReturnImageFiles,
     returnImagePreviews,
     setReturnImagePreviews
   } = useContext(ReturnDataContext);
@@ -68,18 +69,21 @@ const ReturnForm = ({ handleNext, handleBack }) => {
     remove(index);
   }
 
-  const addReturnImage = (e, index) => {
+  const addReturnImage = async (e, index) => {
     const file = e.target.files[0];
     const imageUrl = URL.createObjectURL(file);
 
-    setAipReturnImageFiles((prevApiReturnImageFiles) => {
+    const resizedApiReturnImage = await resizeProjectImages(file, 600, 400);
+    const resizedReturnImage = await resizeProjectImages(file, 300, 200);
+
+    setApiReturnImageFiles((prevApiReturnImageFiles) => {
       const newApiReturnImageFiles = [...prevApiReturnImageFiles];
-      newApiReturnImageFiles[index] = file;
+      newApiReturnImageFiles[index] = resizedApiReturnImage;
       return newApiReturnImageFiles;
     });
     setReturnImagePreviews((prevReturnImagePreviews) => {
       const newReturnImagePreviews = [...prevReturnImagePreviews];
-      newReturnImagePreviews[index] = imageUrl;
+      newReturnImagePreviews[index] = URL.createObjectURL(resizedReturnImage);
       return newReturnImagePreviews;
     });
 
@@ -97,7 +101,7 @@ const ReturnForm = ({ handleNext, handleBack }) => {
       return newReturnImagePreviews;
     });
 
-    setAipReturnImageFiles((prevApiReturnImageFiles) => {
+    setApiReturnImageFiles((prevApiReturnImageFiles) => {
       const newApiReturnImageFiles = [...prevApiReturnImageFiles];
       newApiReturnImageFiles[index] = null;
       return newApiReturnImageFiles;
@@ -138,7 +142,7 @@ const ReturnForm = ({ handleNext, handleBack }) => {
             )}
             {returnImagePreviews[index] && (
               <div>
-                <img src={returnImagePreviews[index]} alt={`プレビュー${index + 1}`} style={{ width: '200px', height: '200px' }} />
+                <img src={returnImagePreviews[index]} alt={`プレビュー${index + 1}`} style={{ width: '300px'}} />
                 <button type='button' onClick={() => removeReturnImage(index)}>削除</button>
               </div>
             )}

--- a/src/contexts/ProjectContext.jsx
+++ b/src/contexts/ProjectContext.jsx
@@ -18,6 +18,7 @@ export const ProjectDataProvider = ({ children }) => {
   const [apiImageFiles, setApiImageFiles] = useState([]);
   const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
   const [published, setPublished] = useState(false);
+  const [isEdit, setIsEdit] = useState(false);
 
   return (
     <ProjectDataContext.Provider
@@ -32,6 +33,8 @@ export const ProjectDataProvider = ({ children }) => {
         setPublished,
         editorState,
         setEditorState,
+        isEdit,
+        setIsEdit,
       }}
     >
       {children}
@@ -51,7 +54,7 @@ export const ReturnDataProvider = ({ children }) => {
     ]
   });
   const [returnImagePreviews, setReturnImagePreviews] = useState([]);
-  const [apiReturnImageFiles, setAipReturnImageFiles] = useState([]);
+  const [apiReturnImageFiles, setApiReturnImageFiles] = useState([]);
 
   return (
     <ReturnDataContext.Provider
@@ -59,7 +62,7 @@ export const ReturnDataProvider = ({ children }) => {
         returnFormData,
         setReturnFormData,
         apiReturnImageFiles,
-        setAipReturnImageFiles,
+        setApiReturnImageFiles,
         returnImagePreviews,
         setReturnImagePreviews
       }}

--- a/src/pages/Content.jsx
+++ b/src/pages/Content.jsx
@@ -6,6 +6,28 @@ import SignUpForm from '../components/Auth/SignUpForm';
 import SignInForm from '../components/Auth/SignInForm';
 import CreateProject from '../components/Project/CreateProject';
 import CreatedProjectList from '../components/Project/CreatedProjectList';
+import EditProject from '../components/Project/EditProject';
+import { ProjectDataProvider, ReturnDataProvider } from '../contexts/ProjectContext';
+
+const CreateProjectWrapper = () => {
+  return (
+    <ProjectDataProvider>
+      <ReturnDataProvider>
+        <CreateProject />
+      </ReturnDataProvider>
+    </ProjectDataProvider>
+  );
+};
+
+const EditProjectWrapper = () => {
+  return (
+    <ProjectDataProvider>
+      <ReturnDataProvider>
+        <EditProject />
+      </ReturnDataProvider>
+    </ProjectDataProvider>
+  );
+};
 
 const Content = () => {
   return (
@@ -16,8 +38,9 @@ const Content = () => {
           <Route index element={<Top />} />
           <Route path='/signup_form' element={<SignUpForm />} />
           <Route path='/signin_form' element={<SignInForm />} />
-          <Route path='/new/project' element={<CreateProject />} />
+          <Route path='/new/project' element={<CreateProjectWrapper />} />
           <Route path='/projects' element={<CreatedProjectList />} />
+          <Route path='/projects/edit/:project_id' element={<EditProjectWrapper />} />
         </Routes>
       </Grid>
     </Grid>


### PR DESCRIPTION
### 【実装内容】
主にプロジェクト編集機能を実装しました。
また、プロジェクト作成時の画像のリサイズやバリデーションを追加しました。

### 【共有事項】
プロジェクト説明を入力するために、リッチテキストエディタで画像挿入時にAWSのS3にアップロードしてそのURLをプロジェクト説明のステートにセットしていたのですが、
プロジェクト編集時にどうしても403 Forbiddenエラーが発生してしまうのでひとまず画像を扱わない方向にしました。
S3のアクセス権がないとのことで、アップロードされた画像のURLが一時的な署名付きURLである可能性がありそれが原因とのことですが、S3のアクセス権の設定が上手くいかなかったので、後ほど余裕があれば調査し修正します。
