### PR TITLE
プロジェクト詳細ページの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.4.0",
         "axios-case-converter": "^1.1.0",
+        "date-fns": "^2.30.0",
         "draft-js": "^0.10.5",
         "draft-js-image-plugin": "^2.0.7",
         "draftjs-to-html": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.4.0",
     "axios-case-converter": "^1.1.0",
+    "date-fns": "^2.30.0",
     "draft-js": "^0.10.5",
     "draft-js-image-plugin": "^2.0.7",
     "draftjs-to-html": "^0.9.1",

--- a/src/components/Project/CreatedProjectList.jsx
+++ b/src/components/Project/CreatedProjectList.jsx
@@ -41,7 +41,12 @@ const CreatedProjectList = () => {
         ) : (
           <p>プロジェクト画像がありません</p>
         )}
-        <Link to={`/projects/edit/${project.id}`}>編集</Link>
+        <div>
+          <Link to={`/projects/edit/${project.id}`}>編集</Link>
+        </div>
+        <div>
+          <Link to={`/projects/${project.id}`}>プロジェクトページへ</Link>
+        </div>
       </div>
     ))}
   </div>

--- a/src/components/Project/EditProject.jsx
+++ b/src/components/Project/EditProject.jsx
@@ -40,7 +40,7 @@ const EditProject = () => {
           headers: headers,
         });
 
-        const projectData = response.data;
+        const projectData = response.data.project;
 
         let catchCopiesArray = [];
         catchCopiesArray = JSON.parse(projectData.catchCopies);

--- a/src/components/Project/IndexProject.jsx
+++ b/src/components/Project/IndexProject.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react'
+import clientApi from '../../api/client';
+import Cookies from 'js-cookie';
+import { Link } from 'react-router-dom';
+
+const IndexProject = () => {
+  const [projects, setProjects] = useState([]);
+
+  useEffect(() => {
+    const fetchProjects = async () => {
+      try {
+        const headers = {
+          'access-token': Cookies.get('_access_token'),
+          'client': Cookies.get('_client'),
+          'uid': Cookies.get('_uid'),
+        };
+
+        const response = await clientApi.get('/projects', {
+          headers: headers,
+        });
+
+        console.log('API レスポンス', response.data)
+        setProjects(response.data)
+      } catch (error) {
+        console.error('API レスポンスの取得に失敗しました', error);
+      }
+    };
+
+    fetchProjects();
+  }, []);
+
+
+  return (
+    <div>
+    {projects.map((project) => (
+      <div key={project.id}>
+        <h2>{project.title}</h2>
+        <h2>プロジェクトID:{project.id}</h2>
+        {project.projectImages && project.projectImages[0] ? (
+          <img src={project.projectImages[0].url} alt={project.title} style={{width: '300px'}} />
+        ) : (
+          <p>プロジェクト画像がありません</p>
+        )}
+        <Link to={`/projects/${project.id}`}>プロジェクトページへ</Link>
+      </div>
+    ))}
+  </div>
+  )
+}
+
+export default IndexProject

--- a/src/components/Project/ReturnInfo.jsx
+++ b/src/components/Project/ReturnInfo.jsx
@@ -1,0 +1,40 @@
+import React, { useContext } from 'react'
+import Button from "@material-ui/core/Button"
+import { Link, useNavigate } from 'react-router-dom';
+import { ReturnInfoContext } from './ReturnInfoContext';
+
+const ReturnInfo = ({ project_id, isPurchaseDisabled }) => {
+  const {returnData} = useContext(ReturnInfoContext);
+
+  return (
+    <>
+      <h2>リターン情報</h2>
+      {returnData.map((returnItem, index) => {
+        return(
+          <div key={index}>
+            {console.log(returnItem)}
+            <p>リターン名:{returnItem.name}</p>
+            <p>説明: {returnItem.description}</p>
+            <p>価格: {returnItem.price}</p>
+            <p>{returnItem.stock_count === 0 ? '売り切れました' : `残り${returnItem.stock_count}個`}</p>
+            <p>支援者：{returnItem.supporter_count}人</p>
+            <img src={returnItem.return_image.url} alt={`${returnItem.name} - 画像${index + 1}`} style={{width: '300px'}} />
+            {/* <Link to={`/purchase/confirm?return_id=${returnItem.id}&project_id=${project_id}`}>購入する</Link> */}
+            <Button
+              variant='contained'
+              size='large'
+              color='primary'
+              component={Link}
+              to={`/purchase/confirm?return_id=${returnItem.id}&project_id=${project_id}`}
+              disabled={returnItem.stock_count === 0 || isPurchaseDisabled}
+            >
+              このリターンを応援購入する
+            </Button>
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export default ReturnInfo

--- a/src/components/Project/ReturnInfoContext.jsx
+++ b/src/components/Project/ReturnInfoContext.jsx
@@ -1,0 +1,13 @@
+import React, { createContext, useState } from 'react'
+
+export const ReturnInfoContext = createContext();
+
+export const ReturnInfoProvider = ({ children }) => {
+  const [returnData, setReturnData] = useState([]);
+
+  return (
+    <ReturnInfoContext.Provider value={{returnData, setReturnData}}>
+      {children}
+    </ReturnInfoContext.Provider>
+  )
+}

--- a/src/components/Project/ReturnPurchaseConfirm.jsx
+++ b/src/components/Project/ReturnPurchaseConfirm.jsx
@@ -1,0 +1,75 @@
+import React, { useContext, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom';
+import { ReturnInfoContext } from './ReturnInfoContext'
+import clientApi from '../../api/client';
+import Cookies from 'js-cookie';
+import { Button } from '@material-ui/core';
+import Modal from '@mui/material/Modal';
+
+const ReturnPurchaseConfirm = () => {
+  const { project_id } = useParams();
+  const { returnData } = useContext(ReturnInfoContext);
+  const navigate = useNavigate();
+  const queryParams = new URLSearchParams(window.location.search);
+  const selectedReturnId = queryParams.get('return_id');
+  const selectedProjectId = queryParams.get('project_id');
+  const selectedReturn = returnData.find(item => item.id === parseInt(selectedReturnId));
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+
+  console.log('project_id', selectedProjectId)
+  const handleConfirm = async () => {
+    const confirmResult = window.confirm('リターンを購入してもよろしいですか？');
+
+    if (confirmResult) {
+      try {
+        const combinedData = {
+          project_id: selectedProjectId,
+          return_id: selectedReturn.id,
+          quantity: 1,
+          amount: selectedReturn.price
+        }
+
+        const response = await clientApi.post('/purchases', combinedData, {
+          headers: {
+            'access-token': Cookies.get('_access_token'),
+            'client': Cookies.get('_client'),
+            'uid': Cookies.get('_uid'),
+          }
+        });
+
+        console.log('API レスポンス', response.data);
+        setShowSuccessModal(true)
+      } catch (error) {
+        console.error('データの送信に失敗しました', error);
+      }
+    }
+  }
+
+  if (!selectedReturn) {
+    return <div>画面がリロードされました。リターンの購入からやり直してください。</div>;
+  }
+
+  return (
+    <>
+      <div>
+        <h2>応援購入するリターン</h2>
+        <p>リターン名：{selectedReturn.name}</p>
+        <p>説明: {selectedReturn.description}</p>
+        <p>価格: {selectedReturn.price}</p>
+        <img src={selectedReturn.return_image.url} alt={'selectedReturn.name'} style={{width: '300px'}} />
+      </div>
+      <Button variant="contained" color="primary" onClick={handleConfirm}>
+        リターン購入を確定する
+      </Button>
+      <Modal open={showSuccessModal} onClose={() => navigate(`/projects/${selectedProjectId}`)}>
+        <div className='modal-overlay'>
+          <div className='modal-content'>
+            <h2 className='modal-title'>リターンを購入しました</h2>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}
+
+export default ReturnPurchaseConfirm

--- a/src/components/Project/ShowProject.jsx
+++ b/src/components/Project/ShowProject.jsx
@@ -1,0 +1,178 @@
+import React, { useContext, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import Cookies from 'js-cookie'
+import clientApi from '../../api/client'
+import { parseISO, format } from 'date-fns'
+import { Editor, convertFromRaw, EditorState } from 'draft-js';
+import ReturnInfo from './ReturnInfo'
+import { ReturnInfoContext } from './ReturnInfoContext'
+import { AuthContext } from '../../lib/AuthContext'
+
+const ShowProject = () => {
+  const { project_id } = useParams();
+  const { setReturnData } = useContext(ReturnInfoContext)
+  const {isSignedIn, currentUser, loading} = useContext(AuthContext);
+  const [projectData, setProjectData] = useState({
+    title: '',
+    catch_copies: [''],
+    goal_amount: '',
+    start_date: '',
+    end_date: '',
+    project_images: [''],
+  });
+  const [descriptionEditorState, setDescriptionEditorState] = useState(EditorState.createEmpty());
+  const [isPurchaseDisabled, setIsPurchaseDisabled] =useState(false);
+
+  useEffect(() => {
+    const fetchProjectData = async () => {
+      try {
+        const response = await clientApi.get(`/projects/${project_id}`)
+
+        const resData = response.data
+        const resProjectData = response.data.project;
+
+        if (resProjectData.isPublished || (isSignedIn && resProjectData.userId === currentUser.id)) {
+          const parsedStartDate = parseISO(resProjectData.startDate);
+          const parsedEndDate = parseISO(resProjectData.endDate);
+
+          const now = new Date();
+          const isProjectStarted = parsedStartDate <= now;
+          const isProjectEnded = parsedEndDate < now;
+          setIsPurchaseDisabled(!isProjectStarted || isProjectEnded);
+
+          const descriptionData = JSON.parse(resProjectData.description);
+          const contentState = convertFromRaw({
+            blocks: descriptionData.blocks,
+            entityMap: descriptionData.entityMap,
+          });
+          const editorState = EditorState.createWithContent(contentState);
+          setDescriptionEditorState(editorState);
+
+          const successRate = Math.floor(resData.totalAmount / resProjectData.goalAmount * 100)
+
+          setProjectData({
+            title: resProjectData.title,
+            goal_amount: resProjectData.goalAmount,
+            start_date: parsedStartDate,
+            end_date: parsedEndDate,
+            catch_copies: JSON.parse(resProjectData.catchCopies),
+            project_images: resProjectData.projectImages,
+            description: descriptionEditorState,
+            total_amount: resData.totalAmount,
+            support_count: resData.supportCount,
+            success_rate: successRate,
+            is_published: resProjectData.isPublished,
+            user: resData.user
+          })
+
+          setReturnData(resProjectData.returns.map(returnItem => ({
+            id: returnItem.id,
+            name: returnItem.name,
+            description: returnItem.description,
+            price: returnItem.price,
+            stock_count: returnItem.stockCount,
+            return_image: returnItem.returnImage,
+            supporter_count: returnItem.supporterCount,
+          })))
+        } else {
+          setProjectData(null)
+        }
+
+        console.log('API レスポンス', response.data)
+      } catch (error) {
+        console.error('API レスポンスの取得に失敗しました', error);
+      }
+    }
+
+    fetchProjectData();
+  }, [loading])
+
+  if (loading) {
+    return <p>ロード中...</p>
+  }
+
+  // 開始日と終了日を適切に表示
+  const formattedStartDate = projectData ? (projectData.start_date ? format(projectData.start_date, 'yyyy年MM月dd日 HH:mm') : '') : '';
+  const formattedEndDate = projectData ? (projectData.end_date ? format(projectData.end_date, 'yyyy年MM月dd日 HH:mm') : '') : '';
+
+  // プロジェクトの残り日時を計算
+  const now = new Date();
+  const remainingTime = Math.max(projectData && projectData.end_date - now, 0);
+  const remainingDays = Math.floor(remainingTime / (1000 * 60 * 60 *24));
+  const remainingHours = Math.floor(remainingTime % (1000 * 60 * 60 * 24) / (1000 * 60 * 60));
+  const remainingMinutes = Math.floor(remainingTime % (1000 * 60 * 60 * 24) / (1000 * 60));
+
+  // 実施期間によるテキストの表示
+  let remainingText = '';
+  if (projectData && projectData.start_date > new Date()) {
+    remainingText = `${formattedStartDate}に開始予定です。`;
+  } else if (remainingDays > 0) {
+    remainingText = `あと${remainingDays}日`;
+  } else if (remainingHours > 0) {
+    remainingText = `あと${remainingHours}時間`;
+  } else if (remainingMinutes > 0) {
+    remainingText = `あと${remainingMinutes}分`;
+  } else {
+    remainingText = '終了しました'
+  }
+
+  // プログレスバーと達成の有無
+  const progress = projectData ? Math.min((projectData.total_amount / projectData.goal_amount) * 100, 100) : 0;
+  const isAchived = projectData ? (progress === 100) : false;
+
+  console.log('購入できません', isPurchaseDisabled)
+  // console.log('公開状態', projectData.is_published)
+
+  return (
+    <>
+      <h2>プロジェクトページ</h2>
+      {console.log(projectData)}
+      {projectData !== null ? (
+        <>
+          <h2>{projectData.title}</h2>
+          {projectData.project_images ? (
+            projectData.project_images.map((projectImage, index) => {
+              return (
+                <img
+                  key={index}
+                  src={projectImage.url}
+                  alt={`${projectData.title} - 画像${index + 1}`}
+                  style={{width: '300px'}}
+                />
+              );
+            })
+          ) : (
+            <p>プロジェクト画像がありません</p>
+          )}
+          <p>応援購入総額{projectData.total_amount}円</p>
+          <p>目標金額{projectData.goal_amount}円</p>
+          <p>達成率{projectData.success_rate}%</p>
+          <progress value={progress} max='100'></progress>
+          {isAchived ? <p>Success!</p> : <p>未達成</p>}
+          <p>サポーター{projectData.support_count}人</p>
+          {projectData.catch_copies.map((catchCopy, index) => (
+            <p key={index}>{catchCopy}</p>
+          ))}
+          <p>{remainingText}</p>
+          <p>
+            このプロジェクトの実施期間は
+            {formattedStartDate}〜
+            {formattedEndDate}
+            です
+          </p>
+          <div>
+            <p>プロジェクト作成者：{projectData.user && projectData.user.name ? projectData.user.name : ''}</p>
+          </div>
+          <Editor editorState={descriptionEditorState} readOnly />
+          <div>
+            <ReturnInfo project_id={project_id} isPurchaseDisabled={isPurchaseDisabled} />
+          </div>
+        </>
+      ) : (
+        <p>このプロジェクトは非公開です。</p>
+      )}
+    </>
+  )
+}
+
+export default ShowProject

--- a/src/components/Top.jsx
+++ b/src/components/Top.jsx
@@ -23,7 +23,10 @@ const Top = () => {
         <Link to={`/new/project`}>プロジェクトをはじめる</Link>
       </div>
       <div>
-        <Link to={`/projects`}>作成したプロジェクト一覧</Link>
+        <Link to={`/my_projects`}>作成したプロジェクト一覧</Link>
+      </div>
+      <div>
+        <Link to={`/projects`}>全てのプロジェクト一覧</Link>
       </div>
     </>
   )

--- a/src/lib/PrivateRoute.jsx
+++ b/src/lib/PrivateRoute.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Route, Navigate } from 'react-router-dom';
+import { AuthContext } from '../lib/AuthContext';
+
+const PrivateRoute = ({ element }) => {
+  const { isSignedIn } = React.useContext(AuthContext);
+
+  return isSignedIn ? element : <Navigate to="/signin_form" />;
+};
+
+export default PrivateRoute;

--- a/src/pages/Content.jsx
+++ b/src/pages/Content.jsx
@@ -8,6 +8,12 @@ import CreateProject from '../components/Project/CreateProject';
 import CreatedProjectList from '../components/Project/CreatedProjectList';
 import EditProject from '../components/Project/EditProject';
 import { ProjectDataProvider, ReturnDataProvider } from '../contexts/ProjectContext';
+import IndexProject from '../components/Project/IndexProject';
+import ShowProject from '../components/Project/ShowProject';
+import ReturnPurchaseConfirm from '../components/Project/ReturnPurchaseConfirm';
+import { ReturnInfoProvider } from '../components/Project/ReturnInfoContext';
+import PurchaseHistory from '../components/Project/PurchaseHistory';
+import PrivateRoute from '../lib/PrivateRoute';
 
 const CreateProjectWrapper = () => {
   return (
@@ -38,9 +44,12 @@ const Content = () => {
           <Route index element={<Top />} />
           <Route path='/signup_form' element={<SignUpForm />} />
           <Route path='/signin_form' element={<SignInForm />} />
-          <Route path='/new/project' element={<CreateProjectWrapper />} />
-          <Route path='/projects' element={<CreatedProjectList />} />
+          <Route path='/new/project' element={<PrivateRoute element={<CreateProjectWrapper />} />} />
           <Route path='/projects/edit/:project_id' element={<EditProjectWrapper />} />
+          <Route path='/my_projects' element={<PrivateRoute element={<CreatedProjectList />} />} />
+          <Route path='/projects' element={<IndexProject />} />
+          <Route path='/projects/:project_id' element={<ReturnInfoProvider><ShowProject /></ReturnInfoProvider>} />
+          <Route path='/purchase/confirm' element={<ReturnInfoProvider><ReturnPurchaseConfirm /></ReturnInfoProvider>} />
         </Routes>
       </Grid>
     </Grid>

--- a/src/pages/Content.jsx
+++ b/src/pages/Content.jsx
@@ -12,7 +12,6 @@ import IndexProject from '../components/Project/IndexProject';
 import ShowProject from '../components/Project/ShowProject';
 import ReturnPurchaseConfirm from '../components/Project/ReturnPurchaseConfirm';
 import { ReturnInfoProvider } from '../components/Project/ReturnInfoContext';
-import PurchaseHistory from '../components/Project/PurchaseHistory';
 import PrivateRoute from '../lib/PrivateRoute';
 
 const CreateProjectWrapper = () => {


### PR DESCRIPTION
### 【実装内容】
主にプロジェクト詳細ページと、そのページにおけるリターン購入機能を実装しました。
他にも
・プロジェクト一覧の追加
・非ログインユーザーがプロジェクト作成画面などにアクセスしようとした時にログイン画面にリダイレクトするためPrivateRouteを追加
を進めました。

### プロジェクト詳細画面
GET /api/v1/projects/{project_id}でプロジェクト情報とそれに紐づくリターン情報を取得し、
・応援購入総額
・サポーター人数
・達成率
・残り日時
などを改めて計算し表示させました。

### リターン購入機能
POST /api/v1/purchasesでrailsのPurchaseテーブルにリターン購入情報を保存するよう実装しました。
リターンが購入されるとその在庫（stock_count）が減少するなどの実装はrails側で行いました。