### PR TITLE
購入履歴画面の追加 / プロジェクト詳細画面のレイアウト調整

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
         "@mui/material": "^5.14.3",
+        "@splidejs/react-splide": "^0.7.12",
+        "@splidejs/splide": "^4.1.4",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -4202,6 +4204,19 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@splidejs/react-splide": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@splidejs/react-splide/-/react-splide-0.7.12.tgz",
+      "integrity": "sha512-UfXH+j47jsMc4x5HA/aOwuuHPqn6y9+ZTNYPWDRD8iLKvIVMZlzq2unjUEvyDAU+TTVPZOXkG2Ojeoz0P4AkZw==",
+      "dependencies": {
+        "@splidejs/splide": "^4.1.3"
+      }
+    },
+    "node_modules/@splidejs/splide": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
+      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -23230,6 +23245,19 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@splidejs/react-splide": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@splidejs/react-splide/-/react-splide-0.7.12.tgz",
+      "integrity": "sha512-UfXH+j47jsMc4x5HA/aOwuuHPqn6y9+ZTNYPWDRD8iLKvIVMZlzq2unjUEvyDAU+TTVPZOXkG2Ojeoz0P4AkZw==",
+      "requires": {
+        "@splidejs/splide": "^4.1.3"
+      }
+    },
+    "@splidejs/splide": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
+      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA=="
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@mui/material": "^5.14.3",
+    "@splidejs/react-splide": "^0.7.12",
+    "@splidejs/splide": "^4.1.4",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,48 @@
-import { Grid } from "@material-ui/core";
+import { Grid, CssBaseline, Paper, makeStyles } from "@material-ui/core";
 import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "./lib/AuthContext";
 import Header from "./components/Header";
 import Content from "./pages/Content";
 
+const useStyles = makeStyles((theme) => ({
+  root: {
+    // minHeight: '300vh',
+    backgroundColor: '#f7f7f7',
+    padding: theme.spacing(2),
+  },
+  mainContainer: {
+    padding: theme.spacing(3),
+  },
+  paper: {
+    backgroundColor: 'white',
+    boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.1)',
+    borderRadius: theme.spacing(1),
+    padding: theme.spacing(3),
+    width: '100%',
+    maxWidth: '1200px',
+    // minHeight: '500px',
+    margin: '0 auto',
+  }
+}));
+
 function App() {
+  const classes = useStyles();
+
   return (
-    <Grid container direction='column'>
+    <Grid container direction='column' className={classes.root}>
       <AuthProvider>
+        <CssBaseline />
         <BrowserRouter>
           <Header />
-          <div style={{ padding: 30 }}>
-            <Content />
-          </div>
+          <Grid container justifyContent='center' className={classes.mainContainer}>
+            <Paper elevation={3} className={classes.paper}>
+              <Content />
+            </Paper>
+          </Grid>
         </BrowserRouter>
       </AuthProvider>
     </Grid>
-  )
+  );
 }
 
 export default App;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -47,11 +47,6 @@ const Header = () => {
         Cookies.remove('_uid')
         Cookies.remove('_expiry');
         Cookies.remove('_token-type');
-        Cookies.remove('access_token')
-        Cookies.remove('client')
-        Cookies.remove('uid')
-        Cookies.remove('expiry');
-        Cookies.remove('token-type');
 
         setIsSignedIn(false);
         navigate('/');

--- a/src/components/Project/ProjectImageSlideshow.jsx
+++ b/src/components/Project/ProjectImageSlideshow.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Splide, SplideSlide } from '@splidejs/react-splide'
+import '@splidejs/splide/css'
+import '@splidejs/splide/dist/css/themes/splide-default.min.css'
+import { makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  heroImage: {
+    maxWidth: '600px',
+  },
+}));
+
+const ProjectImageSlideshow = ({ projectData }) => {
+  const projectImages =projectData.project_images ? projectData.project_images : '';
+  const classes = useStyles();
+
+  return (
+    <Splide
+      options={{
+        type: 'slide',
+        perPage: 1,
+        pagination: true,
+        arrows: true,
+      }}
+    >
+      {projectImages.map((projectImage, index) => (
+        <SplideSlide key={index}>
+          <div style={{ maxWidth: '600px', margin: '0 auto' }}>
+            <img
+              src={projectImage.url}
+              alt={`${projectImage.title} - 画像${index + 1}`}
+              style={{ margin: 0 }}
+            />
+          </div>
+        </SplideSlide>
+      ))}
+    </Splide>
+  )
+}
+
+export default ProjectImageSlideshow

--- a/src/components/Project/PurchaseHistory.jsx
+++ b/src/components/Project/PurchaseHistory.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react'
+import clientApi from '../../api/client';
+import Cookies from 'js-cookie';
+import { Link } from 'react-router-dom';
+
+const PurchaseHistory = () => {
+  const [projects, setProjects] = useState();
+  const [returns, setReturns] = useState();
+  const [purchasesData, setPurchasesData] = useState();
+
+
+  useEffect(() => {
+    const fetchPurchases = async () => {
+      try {
+        const headers = {
+          'access-token': Cookies.get('_access_token'),
+          'client': Cookies.get('_client'),
+          'uid': Cookies.get('_uid'),
+        };
+
+        const response = await clientApi.get('/purchases', {
+          headers: headers,
+        });
+
+        console.log('API Purchase レスポンス', response.data);
+        setPurchasesData(response.data)
+      } catch (error) {
+        console.error('API レスポンスの取得に失敗しました', error);
+      }
+    };
+
+    fetchPurchases();
+  }, []);
+
+  return (
+    <>
+      <h2>購入履歴</h2>
+      {purchasesData &&
+      <>
+        {console.log('purchasesData', purchasesData)}
+        {purchasesData.map((purchase) => (
+          <div key={purchase.id}>
+            <p>購入ID:{purchase.id}</p>
+            <p>購入日時:{purchase.createdAt}</p>
+            <h2>{purchase.return.name}</h2>
+            {purchase.return.returnImage &&
+              <img src={purchase.return.returnImage.url} aria-colcount={`購入履歴 - ${purchase.return.name}`} style={{width: '250px'}} />
+            }
+            <p>{`リターン単価:${purchase.return.price}円`}</p>
+            <p>{`数量:${purchase.quantity}個`}</p>
+            <h3>{`合計 ${purchase.amount}円`}</h3>
+            <p>プロジェクト名:{purchase.project.title}</p>
+            {purchase.project.projectImages &&
+              <img src={purchase.project.projectImages[0].url} aria-colcount={`購入履歴 - ${purchase.project.title}`} style={{width: '250px'}} />
+            }
+          </div>
+        ))}
+      </>
+      }
+    </>
+  )
+}
+
+export default PurchaseHistory

--- a/src/components/Project/ReturnInfo.jsx
+++ b/src/components/Project/ReturnInfo.jsx
@@ -8,10 +8,10 @@ const ReturnInfo = ({ project_id, isPurchaseDisabled }) => {
 
   return (
     <>
-      <h2>リターン情報</h2>
+      <h2>リターン</h2>
       {returnData.map((returnItem, index) => {
         return(
-          <div key={index}>
+          <div key={index} style={{backgroundColor: '#f7f7f7'}}>
             {console.log(returnItem)}
             <p>リターン名:{returnItem.name}</p>
             <p>説明: {returnItem.description}</p>

--- a/src/components/Project/ShowProject.jsx
+++ b/src/components/Project/ShowProject.jsx
@@ -7,6 +7,57 @@ import { Editor, convertFromRaw, EditorState } from 'draft-js';
 import ReturnInfo from './ReturnInfo'
 import { ReturnInfoContext } from './ReturnInfoContext'
 import { AuthContext } from '../../lib/AuthContext'
+import { Grid, Paper, Typography, makeStyles } from '@material-ui/core'
+import ProjectImageSlideshow from './ProjectImageSlideshow'
+import { Splide, SplideSlide } from '@splidejs/react-splide'
+import '@splidejs/splide/css'
+import '@splidejs/splide/dist/css/themes/splide-default.min.css'
+
+const useStyles = makeStyles((theme) => ({
+  heroContainer: {
+    width: '100%',
+    maxWidth: '1200px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: theme.spacing(3),
+  },
+  heroImage: {
+    width: '100%',
+    maxWidth: '650px',
+    marginRight: theme.spacing(3),
+  },
+  mainContainer: {
+    display: 'flex',
+    marginBottom: theme.spacing(3),
+  },
+  mainContent: {
+    flexGrow: 1,
+    marginRight: theme.spacing(3),
+  },
+  sideBar: {
+    flexShrink: 0,
+    width: '300px',
+  },
+  projectTitle: {
+    textAlign: 'center',
+    marginBottom: theme.spacing(3),
+  },
+  projectInfo: {
+    marginLeft: '50px',
+    marginBottom: theme.spacing(2),
+  },
+  descriptionEditor: {
+    marginBottom: theme.spacing(3),
+  },
+  splideContainer: {
+    width: '100%',
+    maxWidth: '650px',
+  },
+  slideImage: {
+    width: '100%',
+  },
+}));
 
 const ShowProject = () => {
   const { project_id } = useParams();
@@ -22,6 +73,7 @@ const ShowProject = () => {
   });
   const [descriptionEditorState, setDescriptionEditorState] = useState(EditorState.createEmpty());
   const [isPurchaseDisabled, setIsPurchaseDisabled] =useState(false);
+  const classes = useStyles();
 
   useEffect(() => {
     const fetchProjectData = async () => {
@@ -107,11 +159,11 @@ const ShowProject = () => {
   if (projectData && projectData.start_date > new Date()) {
     remainingText = `${formattedStartDate}に開始予定です。`;
   } else if (remainingDays > 0) {
-    remainingText = `あと${remainingDays}日`;
+    remainingText = `${remainingDays}日`;
   } else if (remainingHours > 0) {
-    remainingText = `あと${remainingHours}時間`;
+    remainingText = `${remainingHours}時間`;
   } else if (remainingMinutes > 0) {
-    remainingText = `あと${remainingMinutes}分`;
+    remainingText = `${remainingMinutes}分`;
   } else {
     remainingText = '終了しました'
   }
@@ -123,49 +175,97 @@ const ShowProject = () => {
   console.log('購入できません', isPurchaseDisabled)
   // console.log('公開状態', projectData.is_published)
 
+  const dotImages = projectData && projectData.project_images.map((projectImage, index) => ({
+    src: projectImage.url,
+    alt: `${projectImage.title} - 画像${index + 1}`,
+  }))
+
   return (
     <>
-      <h2>プロジェクトページ</h2>
-      {console.log(projectData)}
       {projectData !== null ? (
         <>
-          <h2>{projectData.title}</h2>
-          {projectData.project_images ? (
-            projectData.project_images.map((projectImage, index) => {
-              return (
-                <img
-                  key={index}
-                  src={projectImage.url}
-                  alt={`${projectData.title} - 画像${index + 1}`}
-                  style={{width: '300px'}}
-                />
-              );
-            })
-          ) : (
-            <p>プロジェクト画像がありません</p>
-          )}
-          <p>応援購入総額{projectData.total_amount}円</p>
-          <p>目標金額{projectData.goal_amount}円</p>
-          <p>達成率{projectData.success_rate}%</p>
-          <progress value={progress} max='100'></progress>
-          {isAchived ? <p>Success!</p> : <p>未達成</p>}
-          <p>サポーター{projectData.support_count}人</p>
-          {projectData.catch_copies.map((catchCopy, index) => (
-            <p key={index}>{catchCopy}</p>
-          ))}
-          <p>{remainingText}</p>
-          <p>
-            このプロジェクトの実施期間は
-            {formattedStartDate}〜
-            {formattedEndDate}
-            です
-          </p>
-          <div>
-            <p>プロジェクト作成者：{projectData.user && projectData.user.name ? projectData.user.name : ''}</p>
+          <Typography className={classes.projectTitle} style={{ fontWeight: 'bold', margin: '40px 0' }} variant='h4'>{projectData.title}</Typography>
+          <div className={classes.heroContainer}>
+            <div className={classes.splideContainer}>
+              <Splide
+                options={{
+                  type: 'slide',
+                  perPage: 1,
+                  pagination: true,
+                  arrows: true,
+                }}
+              >
+                {projectData.project_images.map((projectImage, index) => (
+                  <SplideSlide key={index}>
+                    <img
+                      src={projectImage.url}
+                      alt={`${projectImage.title} - 画像${index + 1}`}
+                      className={classes.slideImage}
+                    />
+                  </SplideSlide>
+                ))}
+              </Splide>
+            </div>
+            {/* <ProjectImageSlideshow projectData={projectData}/> */}
+            {/* <img
+              src={projectData.project_images[0].url} // 最初の画像を表示
+              alt={`${projectData.title} - 画像1`}
+              className={classes.heroImage}
+            /> */}
+            {/* {projectData.project_images ? (
+              projectData.project_images.map((projectImage, index) => {
+                return (
+                  <img
+                    key={index}
+                    src={projectImage.url}
+                    alt={`${projectData.title} - 画像${index + 1}`}
+                    style={{width: '300px'}}
+                  />
+                );
+              })
+            ) : (
+              <p>プロジェクト画像がありません</p>
+            )} */}
+            <div className={classes.projectInfo}>
+              <Typography variant='h6'>応援購入総額</Typography>
+              <Typography variant='h3' style={{ fontWeight: 'bold' }}>{projectData.total_amount}円</Typography>
+              <progress value={progress} max='100'></progress>
+              <Typography>達成率{projectData.success_rate}%</Typography>
+              <Typography>目標金額は{projectData.goal_amount}円</Typography>
+              <Typography>{isAchived ? <p>Success!</p> : ''}</Typography>
+              <Typography variant='h6' style={{ marginTop: '20px' }}>支援者数</Typography>
+              <Typography variant='h3' style={{ fontWeight: 'bold' }}>{projectData.support_count}人</Typography>
+              {projectData.start_date > new Date() || projectData.end_date < new Date() ? (
+                <p></p>
+               ) : (
+                <Typography variant='h6' style={{ marginTop: '20px' }}>終了まで残り</Typography>
+               )
+              }
+              <Typography variant='h3' style={{ fontWeight: 'bold' }}>{remainingText}</Typography>
+            </div>
           </div>
-          <Editor editorState={descriptionEditorState} readOnly />
-          <div>
-            <ReturnInfo project_id={project_id} isPurchaseDisabled={isPurchaseDisabled} />
+          <div className={classes.mainContainer}>
+            <div className={classes.mainContent}>
+            <Typography variant='h5' style={{ fontWeight: 'bold' }}>ピックアップ</Typography>
+              {projectData.catch_copies.map((catchCopy, index) => (
+                <p key={index}>{catchCopy}</p>
+              ))}
+              <Typography variant='h5' style={{ fontWeight: 'bold', marginTop: '40px' }}>プレゼンター</Typography>
+              <div>
+                <p>プロジェクト作成者：{projectData.user && projectData.user.name ? projectData.user.name : ''}</p>
+              </div>
+              <Typography variant='h5' style={{ fontWeight: 'bold', marginTop: '30px' }}>プロジェクト概要</Typography>
+              <Editor editorState={descriptionEditorState} readOnly />
+              <p>
+                このプロジェクトの実施期間は
+                {formattedStartDate}〜
+                {formattedEndDate}
+                です
+              </p>
+            </div>
+            <div className={classes.sideBar}>
+              <ReturnInfo project_id={project_id} isPurchaseDisabled={isPurchaseDisabled} />
+            </div>
           </div>
         </>
       ) : (

--- a/src/components/Top.jsx
+++ b/src/components/Top.jsx
@@ -28,6 +28,9 @@ const Top = () => {
       <div>
         <Link to={`/projects`}>全てのプロジェクト一覧</Link>
       </div>
+      <div>
+        <Link to={'/purchases'}>購入履歴</Link>
+      </div>
     </>
   )
 }

--- a/src/lib/PrivateRoute.jsx
+++ b/src/lib/PrivateRoute.jsx
@@ -3,7 +3,11 @@ import { Route, Navigate } from 'react-router-dom';
 import { AuthContext } from '../lib/AuthContext';
 
 const PrivateRoute = ({ element }) => {
-  const { isSignedIn } = React.useContext(AuthContext);
+  const { isSignedIn, loading } = React.useContext(AuthContext);
+
+  if (loading) {
+    return <p>ロード中...</p>
+  }
 
   return isSignedIn ? element : <Navigate to="/signin_form" />;
 };

--- a/src/pages/Content.jsx
+++ b/src/pages/Content.jsx
@@ -37,22 +37,18 @@ const EditProjectWrapper = () => {
 
 const Content = () => {
   return (
-    <Grid container spacing={10}>
-      <Grid item sm={2} />
-      <Grid item lg={8} sm={8}>
-        <Routes>
-          <Route index element={<Top />} />
-          <Route path='/signup_form' element={<SignUpForm />} />
-          <Route path='/signin_form' element={<SignInForm />} />
-          <Route path='/new/project' element={<PrivateRoute element={<CreateProjectWrapper />} />} />
-          <Route path='/projects/edit/:project_id' element={<EditProjectWrapper />} />
-          <Route path='/my_projects' element={<PrivateRoute element={<CreatedProjectList />} />} />
-          <Route path='/projects' element={<IndexProject />} />
-          <Route path='/projects/:project_id' element={<ReturnInfoProvider><ShowProject /></ReturnInfoProvider>} />
-          <Route path='/purchase/confirm' element={<ReturnInfoProvider><ReturnPurchaseConfirm /></ReturnInfoProvider>} />
-        </Routes>
-      </Grid>
-    </Grid>
+    <Routes>
+      <Route index element={<Top />} />
+      <Route path='/signup_form' element={<SignUpForm />} />
+      <Route path='/signin_form' element={<SignInForm />} />
+      <Route path='/new/project' element={<PrivateRoute element={<CreateProjectWrapper />} />} />
+      <Route path='/projects/edit/:project_id' element={<EditProjectWrapper />} />
+      <Route path='/my_projects' element={<PrivateRoute element={<CreatedProjectList />} />} />
+      <Route path='/projects' element={<IndexProject />} />
+      <Route path='/projects/:project_id' element={<ReturnInfoProvider><ShowProject /></ReturnInfoProvider>} />
+      <Route path='/purchase/confirm' element={<ReturnInfoProvider><ReturnPurchaseConfirm /></ReturnInfoProvider>} />
+      <Route path='/purchases' element={<PrivateRoute element={<PurchaseHistory />} />} />
+    </Routes>
   )
 }
 


### PR DESCRIPTION
### 【実装内容】
プロジェクト詳細画面におけるリターンを購入したユーザーが、購入したリターンを確認できる購入履歴ページを実装しました。
また、既に実装済みのプロジェクト詳細画面のレイアウトを調整しました。