### PR TITLE
エンドポイントを参照するのにenv.を介さずにnetlify経由で実行するため修正

### DIFF
--- a/src/api/client.jsx
+++ b/src/api/client.jsx
@@ -5,7 +5,7 @@ const options = {
   ignoreHeaders: true
 }
 
-const baseURL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3001/api/v1';
+const baseURL = REACT_APP_API_BASE_URL || 'http://localhost:3001/api/v1';
 
 const clientApi = applyCaseMiddleware(axios.create({
   baseURL,


### PR DESCRIPTION
### 【実装内容】
NetlifyにてrailsAPIのエンドポイントのベースURLを定義しているので、
`const baseURL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3001/api/v1';`
を
`const baseURL = REACT_APP_API_BASE_URL || 'http://localhost:3001/api/v1';`
に修正